### PR TITLE
feat(list): make the repository set readable without a TTY

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- `gitnow list` prints the known repository set non-interactively, with `--json`, `--cloned` and query filtering
+
 ## [0.6.0] - 2026-09-07
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -138,6 +138,25 @@ list_branches_command = "jj -R {{ bare_path }} bookmark list -T 'name ++ \"\\n\"
 
 Available template variables for worktree commands: `bare_path`, `worktree_path`, `branch`, `ssh_url`.
 
+### Listing repositories
+
+`gitnow list` prints the known repository set and exits — no picker, no clone, no
+sub-shell. Use it from scripts, or to drive completion in another tool.
+
+```bash
+# Every known repository, one relative path per line
+gitnow list
+
+# Filtered with the same fzf-style query as the default command
+gitnow list understory-io
+
+# Only the ones already cloned
+gitnow list --cloned
+
+# JSON, with ssh_url / path / cloned per repo
+gitnow list --json | jq -r '.[] | select(.cloned == false) | .ssh_url'
+```
+
 ### Projects
 
 gitnow supports scratch-pad projects that group multiple repositories into a single directory. This is useful when working on features that span several repos.

--- a/crates/gitnow/src/commands.rs
+++ b/crates/gitnow/src/commands.rs
@@ -1,3 +1,4 @@
+pub mod list;
 pub mod project;
 pub mod root;
 pub mod shell;

--- a/crates/gitnow/src/commands/list.rs
+++ b/crates/gitnow/src/commands/list.rs
@@ -1,0 +1,96 @@
+/// The `list` subcommand prints the known repository set non-interactively.
+///
+/// Repositories are gitnow's unprefixed noun — `gitnow <query>` searches them — so listing
+/// them is `gitnow list`, and `gitnow project list` stays the projects-scoped sibling.
+///
+/// Everything else that reads the repository set either needs a TTY (the picker) or collapses
+/// it to a single top match (the root command's fuzzy path), which leaves no way to enumerate
+/// from a script or another program's completion UI. This is that way.
+use std::path::{Path, PathBuf};
+
+use crate::{
+    app::App, cache::load_repositories, commands::root::RepositoryMatcher,
+    fuzzy_matcher::FuzzyMatcherApp, git_provider::Repository,
+};
+
+#[derive(clap::Parser)]
+pub struct ListCommand {
+    /// Repository query terms. All terms must match.
+    #[arg(value_name = "QUERY", num_args = 0..)]
+    search: Vec<String>,
+
+    /// Output as JSON
+    #[arg(long = "json", default_value = "false")]
+    json: bool,
+
+    /// Only repositories that are already cloned locally
+    #[arg(long = "cloned", default_value = "false")]
+    cloned: bool,
+
+    #[arg(long = "no-cache", default_value = "false")]
+    no_cache: bool,
+}
+
+impl ListCommand {
+    pub async fn execute(&self, app: &'static App) -> anyhow::Result<()> {
+        let repositories = load_repositories(app, !self.no_cache).await?;
+
+        // Same matcher as the root command, so `gitnow list foo` and `gitnow foo` agree on
+        // what "foo" means — this just keeps every hit instead of the best one.
+        let matched = match (!self.search.is_empty()).then(|| self.search.join(" ")) {
+            Some(needle) => app
+                .fuzzy_matcher()
+                .match_repositories(&needle, &repositories),
+            None => repositories,
+        };
+
+        let root = projects_dir(app);
+        let entries: Vec<(Repository, PathBuf, bool)> = matched
+            .into_iter()
+            .map(|repo| {
+                let path = root.join(repo.to_rel_path());
+                let cloned = path.exists();
+                (repo, path, cloned)
+            })
+            .filter(|(_, _, cloned)| *cloned || !self.cloned)
+            .collect();
+
+        if self.json {
+            let out: Vec<serde_json::Value> = entries
+                .iter()
+                .map(|(repo, path, cloned)| {
+                    serde_json::json!({
+                        "provider": repo.provider,
+                        "owner": repo.owner,
+                        "repo_name": repo.repo_name,
+                        "ssh_url": repo.ssh_url,
+                        // Where the repo lives once cloned, whether or not it is yet: the
+                        // path is derived, so a consumer needs `cloned` to tell them apart.
+                        "path": path.display().to_string(),
+                        "cloned": cloned,
+                    })
+                })
+                .collect();
+            println!("{}", serde_json::to_string_pretty(&out)?);
+        } else {
+            // Bare relative paths, one per line: the same label the picker matches on, so
+            // the output pipes straight back into `gitnow` or into fzf.
+            for (repo, _, _) in &entries {
+                println!("{}", repo.to_rel_path().display());
+            }
+        }
+
+        Ok(())
+    }
+}
+
+/// `settings.projects.directory` is not tilde-expanded anywhere in the config layer, so a
+/// configured `~/git` arrives here literally. Reporting that verbatim would hand out a path
+/// that can never exist and a `cloned` that is always false.
+fn projects_dir(app: &'static App) -> PathBuf {
+    let dir: &Path = &app.config.settings.projects.directory;
+    match dir.strip_prefix("~") {
+        Ok(rest) => dirs::home_dir().unwrap_or_default().join(rest),
+        Err(_) => dir.to_path_buf(),
+    }
+}

--- a/crates/gitnow/src/commands/skill.rs
+++ b/crates/gitnow/src/commands/skill.rs
@@ -24,6 +24,7 @@ management, and scratch-pad project workspaces.
 gitnow [OPTIONS] [QUERY]...          # search/clone/open a repository
 gitnow update                        # refresh the local repository cache
 gitnow clone --search <REGEX>        # batch-clone repositories matching a pattern
+gitnow list [QUERY]... [OPTIONS]     # print known repositories (non-interactive)
 gitnow worktree [SEARCH] [OPTIONS]   # create and enter a git worktree for a branch
 gitnow project [SEARCH] [OPTIONS]    # open an existing scratch-pad project
 gitnow project create [NAME]         # create a new multi-repo project
@@ -88,6 +89,41 @@ Clones up to 5 repositories concurrently. Skips repos that already exist locally
 | Flag               | Description                                |
 |--------------------|--------------------------------------------|
 | `--search <REGEX>` | Regular expression to match repository paths |
+
+---
+
+### `gitnow list [QUERY]... [OPTIONS]`
+
+Print the known repository set to stdout and exit. This is the non-interactive
+counterpart to the default command: it never opens a picker, never clones, and
+never spawns a shell, so it is the command to use from a script or to feed
+another program's completion UI.
+
+Repositories are the unprefixed noun (`gitnow <query>` searches them), which is
+why this is `gitnow list` rather than `gitnow repos list`. `gitnow project list`
+remains the projects-scoped sibling.
+
+Default output is one relative path per line (`<provider>/<owner>/<name>`) — the
+same label the picker matches on, so it pipes back into `gitnow` or into fzf.
+
+**Flags:**
+| Flag          | Description                                                    |
+|---------------|----------------------------------------------------------------|
+| `[QUERY]...`  | Same fzf-style matching as the default command; all terms must match |
+| `--json`      | Output as JSON, incl. `ssh_url`, `path` and `cloned`            |
+| `--cloned`    | Only repositories that already exist on disk                    |
+| `--no-cache`  | Skip the local cache; fetch fresh and rewrite it                |
+
+The JSON form carries `path` (where the repo lives once cloned, whether or not
+it is yet) alongside `cloned`, so a consumer can tell "available to clone" from
+"already on disk" without a second stat.
+
+```
+gitnow list                          # every known repository
+gitnow list understory-io            # filtered
+gitnow list --cloned                 # only what is on disk
+gitnow list --json | jq -r '.[].ssh_url'
+```
 
 ---
 

--- a/crates/gitnow/src/main.rs
+++ b/crates/gitnow/src/main.rs
@@ -3,8 +3,8 @@ use std::path::PathBuf;
 use anyhow::Context;
 use clap::{Parser, Subcommand};
 use commands::{
-    clone::CloneCommand, project::ProjectCommand, root::RootCommand, shell::Shell,
-    skill::SkillCommand, update::Update, worktree::WorktreeCommand,
+    clone::CloneCommand, list::ListCommand, project::ProjectCommand, root::RootCommand,
+    shell::Shell, skill::SkillCommand, update::Update, worktree::WorktreeCommand,
 };
 use config::Config;
 use tracing::level_filters::LevelFilter;
@@ -79,6 +79,8 @@ enum Commands {
     Init(Shell),
     Update(Update),
     Clone(CloneCommand),
+    /// List known repositories without opening one
+    List(ListCommand),
     Worktree(WorktreeCommand),
     /// Manage scratch-pad projects with multiple repositories
     Project(ProjectCommand),
@@ -139,6 +141,9 @@ async fn main() -> anyhow::Result<()> {
             Commands::Clone(mut clone) => {
                 clone.execute(app).await?;
             }
+            Commands::List(list) => {
+                list.execute(app).await?;
+            }
             Commands::Worktree(mut wt) => {
                 wt.execute(app, &chooser).await?;
             }
@@ -180,6 +185,16 @@ mod tests {
 
         assert_eq!(command.search, ["mire", "api"]);
         assert!(!command.interactive);
+    }
+
+    #[test]
+    fn list_does_not_swallow_the_root_query() {
+        // `list` is a subcommand, so its terms must land on it and not on the root
+        // command's free-form query, which would silently open a picker instead.
+        let command = Command::try_parse_from(["gitnow", "list", "--json", "mire", "api"]).unwrap();
+
+        assert!(command.search.is_empty());
+        assert!(matches!(command.command, Some(super::Commands::List(_))));
     }
 
     #[test]


### PR DESCRIPTION
## Why

gitnow already knows every repository across the configured providers, but there's no way to hand that set to another program.

- The picker needs a terminal — `gitnow --no-shell --no-clone </dev/null` dies with `Error: No such device or address (os error 6)`.
- The query path deliberately collapses to a single top match.
- `--json` exists only on `project list`, which lists *projects*.

So anything that wants repo autocomplete has to go around gitnow and re-query the provider APIs itself — a second list of the same owners, free to drift from gitnow's. That's the gap this closes.

## Naming

`gitnow list`, not `gitnow repos list`. Repositories are already gitnow's unprefixed noun: you type `gitnow <query>`, never `gitnow repo <query>`. So `gitnow list` reads as "list what the default command searches", and `gitnow project list` stays the prefixed, projects-scoped sibling. Adding a `repos` group would put repository operations in two places at once and make the root command look like a shorthand for something it predates.

Happy to rename if you see it differently — it's a one-line change and it's the part I'm least sure about.

## Shape

```
gitnow list                          # every known repository, one rel path per line
gitnow list understory-io            # same fzf-style query as the default command
gitnow list --cloned                 # only what's on disk
gitnow list --json                   # + ssh_url, path, cloned
```

Reuses `load_repositories` and the root command's `RepositoryMatcher`, so `gitnow list foo` and `gitnow foo` agree on what `foo` means — this just keeps every hit instead of the best one. Never clones, never spawns a shell.

JSON carries `path` and `cloned` as separate fields on purpose: the path is derived from the projects directory and is meaningful whether or not the clone exists, so a consumer needs both to tell "available to clone" from "already here".

## One thing worth flagging

`projects_dir()` re-expands `~` locally, because `settings.projects.directory` is a `PathBuf` that no config code expands — only the separate `settings.project` directory gets `resolve_dir()`. With `projects.directory = "~/git"` (as in the README) the value arrives here literally, so `path` would be unusable and `cloned` false forever.

That looks like a **pre-existing bug beyond this PR**: `commands/root.rs` and the batch `clone` command do the same `projects.directory.join(...).exists()` check, so on a `~`-configured install they never see an existing clone and clone into a literal `./~/git/...`. I kept the fix local rather than expanding inside `ProjectLocation`, since that would move where those commands put their clones — a behaviour change that shouldn't ride along here. Want me to open it separately?

## Verified

`cargo test` (19 passed, incl. a new parse test that `list`'s terms don't leak onto the root query), `cargo clippy` clean on the new file, and against a real cache of 431 repos across 4 owners: filtering, `--cloned` flipping to `true` after an actual clone, and tilde-expanded paths. `cargo fmt` wanted to reformat 14 untouched files — reverted those, so the diff is only the 5 files this needs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)