### PR TITLE
fix(config): a configured `~` was a literal directory, not $HOME

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - `gitnow list` prints the known repository set non-interactively, with `--json`, `--cloned` and query filtering
 
+### Fixed
+- expand `~` in `settings.projects.directory` and `settings.cache.location`; both were used verbatim, so a `~/git` config cloned into a literal `./~/git` relative to the current directory
+
 ## [0.6.0] - 2026-09-07
 
 ### Added

--- a/crates/gitnow/src/commands/list.rs
+++ b/crates/gitnow/src/commands/list.rs
@@ -6,7 +6,7 @@
 /// Everything else that reads the repository set either needs a TTY (the picker) or collapses
 /// it to a single top match (the root command's fuzzy path), which leaves no way to enumerate
 /// from a script or another program's completion UI. This is that way.
-use std::path::{Path, PathBuf};
+use std::path::PathBuf;
 
 use crate::{
     app::App, cache::load_repositories, commands::root::RepositoryMatcher,
@@ -44,7 +44,7 @@ impl ListCommand {
             None => repositories,
         };
 
-        let root = projects_dir(app);
+        let root = &app.config.settings.projects.directory;
         let entries: Vec<(Repository, PathBuf, bool)> = matched
             .into_iter()
             .map(|repo| {
@@ -81,16 +81,5 @@ impl ListCommand {
         }
 
         Ok(())
-    }
-}
-
-/// `settings.projects.directory` is not tilde-expanded anywhere in the config layer, so a
-/// configured `~/git` arrives here literally. Reporting that verbatim would hand out a path
-/// that can never exist and a `cloned` that is always false.
-fn projects_dir(app: &'static App) -> PathBuf {
-    let dir: &Path = &app.config.settings.projects.directory;
-    match dir.strip_prefix("~") {
-        Ok(rest) => dirs::home_dir().unwrap_or_default().join(rest),
-        Err(_) => dir.to_path_buf(),
     }
 }

--- a/crates/gitnow/src/commands/project.rs
+++ b/crates/gitnow/src/commands/project.rs
@@ -8,6 +8,7 @@ use crate::{
     app::App,
     cache::load_repositories,
     chooser::Chooser,
+    config::expand_tilde,
     custom_command::CustomCommandApp,
     fuzzy_matcher::FuzzyMatcherApp,
     interactive::{InteractiveApp, Searchable},
@@ -181,11 +182,7 @@ fn parse_cutoff_date(value: &str) -> Result<chrono::DateTime<Utc>, String> {
 /// Falls back to `default` if the config value is `None`.
 fn resolve_dir(configured: Option<&str>, default: &str) -> PathBuf {
     if let Some(dir) = configured {
-        let path = PathBuf::from(dir);
-        if let Ok(stripped) = path.strip_prefix("~") {
-            return dirs::home_dir().unwrap_or_default().join(stripped);
-        }
-        return path;
+        return expand_tilde(PathBuf::from(dir));
     }
     dirs::home_dir().unwrap_or_default().join(default)
 }

--- a/crates/gitnow/src/config.rs
+++ b/crates/gitnow/src/config.rs
@@ -3,6 +3,19 @@ use std::path::{Path, PathBuf};
 use anyhow::Context;
 use serde::{Deserialize, Serialize};
 
+/// Expand a leading `~` to the home directory.
+///
+/// `toml` deserializes a path into a `PathBuf` verbatim, and nothing downstream resolves it:
+/// a configured `~/git` stays a *relative* path whose first component is literally `~`, so it
+/// resolves against the current directory instead of $HOME. Only `~` and `~/...` are handled,
+/// not `~user/...`, which no shell-less consumer of this config can resolve anyway.
+pub(crate) fn expand_tilde(path: PathBuf) -> PathBuf {
+    match path.strip_prefix("~") {
+        Ok(rest) => dirs::home_dir().unwrap_or_default().join(rest),
+        Err(_) => path,
+    }
+}
+
 #[derive(Debug, Serialize, Deserialize, PartialEq, Clone)]
 pub struct Config {
     #[serde(default)]
@@ -93,8 +106,14 @@ pub struct Projects {
     pub directory: ProjectLocation,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[derive(Debug, Clone, Serialize, PartialEq)]
 pub struct ProjectLocation(PathBuf);
+
+impl<'de> Deserialize<'de> for ProjectLocation {
+    fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        Ok(Self(expand_tilde(PathBuf::deserialize(deserializer)?)))
+    }
+}
 
 impl From<PathBuf> for ProjectLocation {
     fn from(value: PathBuf) -> Self {
@@ -133,8 +152,14 @@ pub struct Cache {
     pub duration: CacheDuration,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[derive(Debug, Clone, Serialize, PartialEq)]
 pub struct CacheLocation(PathBuf);
+
+impl<'de> Deserialize<'de> for CacheLocation {
+    fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        Ok(Self(expand_tilde(PathBuf::deserialize(deserializer)?)))
+    }
+}
 
 impl From<PathBuf> for CacheLocation {
     fn from(value: PathBuf) -> Self {
@@ -300,6 +325,44 @@ impl Config {
 #[cfg(test)]
 mod test {
     use super::*;
+
+    #[test]
+    fn expands_tilde_in_configured_locations() -> anyhow::Result<()> {
+        let home = dirs::home_dir().unwrap_or_default();
+        let config = Config::from_string(
+            r#"
+              [settings]
+              projects = { directory = "~/git" }
+
+              [settings.cache]
+              location = "~/.cache/gitnow"
+            "#,
+        )?;
+
+        // A literal `~` first component would resolve against the current directory, so
+        // these paths must come out absolute or the clone lands in `./~/git/...`.
+        assert_eq!(*config.settings.projects.directory, home.join("git"));
+        assert_eq!(
+            PathBuf::from(config.settings.cache.location.clone()),
+            home.join(".cache/gitnow")
+        );
+
+        Ok(())
+    }
+
+    #[test]
+    fn leaves_absolute_locations_alone() -> anyhow::Result<()> {
+        let config = Config::from_string(
+            r#"
+              [settings]
+              projects = { directory = "/srv/git" }
+            "#,
+        )?;
+
+        assert_eq!(*config.settings.projects.directory, PathBuf::from("/srv/git"));
+
+        Ok(())
+    }
 
     #[test]
     fn test_can_parse_config() -> anyhow::Result<()> {


### PR DESCRIPTION
## The bug

`toml` deserializes these config paths straight into `PathBuf` and nothing downstream resolves them. So `settings.projects.directory = "~/git"` stays a **relative** path whose first component is the character `~`, and every consumer joins it against the current working directory.

Repro — config with `~` paths, run from a temp dir:

```
$ printf '[settings]\nprojects = { directory = "~/gnbug-projects" }\n\n[settings.cache]\nlocation = "~/gnbug-cache"\n' > c.toml
$ gitnow -c c.toml update
$ find . -name '~'
./~
$ ls ./~/gnbug-cache
cache.proto          # …and $HOME/gnbug-cache does not exist
```

## Why it's worth fixing

It's silent, and it degrades five things at once:

- **`settings.cache.location`** — the cache is written to `./~/<…>/cache.proto`, so it's effectively *per-directory*. Run gitnow somewhere new and the cache is cold, which presents as "the cache isn't working" and a full provider re-fetch.
- **`git_clone` / batch `clone`** — clones land in `./~/git/...`, and `--force-refresh` runs `remove_dir_all` on that same wrong path.
- **`commands/root.rs`** — the `project_path.exists()` check is never true for an already-cloned repo, so it re-clones instead of running the post-update hook.
- **`chooser.set`** — writes the unexpanded path, and the shell wrapper in the README does `cd "$target"`. Quoted, so the shell won't expand `~` either, and the cd fails.

The real trap: **`[settings.project] directory`** (singular — the scratch-pad projects dir) *does* expand, via `resolve_dir` in `commands/project.rs`. Two keys one letter apart with opposite behaviour, and the README only ever shows `~` on the one that works — so the habit it teaches you is the one that breaks.

## The fix

Expansion happens once, on the way in, via a `Deserialize` impl on `ProjectLocation` and `CacheLocation`. Doing it at the boundary rather than at the use sites is the point — it was already forgotten at five of them, and a sixth would be just as easy to miss. `resolve_dir` now calls the same shared helper instead of carrying its own copy, so there's one expansion rule.

Only `~` and `~/...` are handled, not `~user/...` — matching what the existing local expansion did, and unresolvable without a passwd lookup anyway.

## Verified

`cargo test` — 20 passing, including two new config tests (tilde expanded for both keys; absolute paths untouched). The repro above comes back clean on the fixed binary: no stray `./~`, cache lands in `$HOME`.

## Rebased on #27

#27 landed while this was in review, so this is rebased onto it. Two consequences:

- The changelog now carries both entries under `[Unreleased]`, `### Added` then `### Fixed`.
- `list.rs`'s local `projects_dir()` tilde expansion is deleted in a follow-up commit — the config layer does it now, so the helper was dead weight and a second place for the rule to drift.

Nice side effect worth noting: the root command visibly benefits. Before, `gitnow --no-clone --no-shell xess` printed `~/git/github.com/caspergreen/xess`; now it prints `/home/casper/git/github.com/caspergreen/xess`, which is what the chooser file needs for `cd "$target"` to work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)