### PR TITLE
feat: work with zero configuration on a fresh install

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - `gitnow list` prints the known repository set non-interactively, with `--json`, `--cloned` and query filtering
+- work with zero configuration on a fresh install: when no providers are configured, gitnow sniffs `gh auth token` (falling back to `GH_TOKEN`/`GITHUB_TOKEN`) and the `gh` login to index your own GitHub. Configuring any provider disables the sniff, and the token is never persisted to the config file nor printed
 
 ### Fixed
 - expand `~` in `settings.projects.directory` and `settings.cache.location`; both were used verbatim, so a `~/git` config cloned into a literal `./~/git` relative to the current directory

--- a/README.md
+++ b/README.md
@@ -70,6 +70,44 @@ gitnow --interactive mire
 
 Configuration lives at `~/.config/gitnow/gitnow.toml` (override with `$GITNOW_CONFIG`).
 
+### Zero-config first run
+
+A fresh install needs no configuration. When gitnow finds **no providers
+configured at all** — no config file, an empty one, or one with only
+`[settings]` — it sniffs your environment for GitHub credentials and indexes
+**your own GitHub** with them:
+
+| Step | Source | Fallback |
+| ---- | ------ | -------- |
+| Token | `gh auth token` | `GH_TOKEN`, then `GITHUB_TOKEN` |
+| Login | `gh api user --jq .login` | none needed — the token already scopes `/user/repos` |
+| Host | `github.com` | — |
+
+So on a machine where you have already run `gh auth login`, this just works:
+
+```bash
+gitnow            # search, clone and enter one of your repositories
+```
+
+Notes:
+
+- **Explicit config always wins.** Configuring *any* provider — GitHub or
+  Gitea — turns the sniff off entirely; your providers are used exactly as
+  written, and gitnow never shells out to `gh`. Customising `[settings]` alone
+  does *not* turn it off, since the trigger is about providers.
+- **The token is never persisted.** The synthesised provider only ever exists
+  in memory: nothing is written to your config file, and the token is
+  re-resolved on each run. Environment tokens are referenced by variable name
+  rather than by value, and tokens are redacted from all debug output.
+- **`gh` is optional.** It is a best-effort shell-out with a timeout, run
+  lazily (only for commands that list repositories, and at most once per run).
+  If neither `gh` nor a token variable is available, gitnow prints a one-line
+  hint and carries on — it never prompts, so automation is unaffected.
+- Organisations are not seeded: `/user/repos` already covers the organisation
+  repositories your token can see.
+
+Writing a real config later needs no migration — it simply takes over.
+
 ### Custom clone command
 
 By default gitnow uses `git clone`. You can override this with any command using a [minijinja](https://docs.rs/minijinja) template:

--- a/crates/gitnow/src/app.rs
+++ b/crates/gitnow/src/app.rs
@@ -1,12 +1,108 @@
-use crate::config::Config;
+use tokio::sync::OnceCell;
+
+use crate::{
+    config::{Config, GitHub},
+    zero_config,
+};
 
 #[derive(Debug)]
 pub struct App {
     pub config: Config,
+
+    /// The zero-config default provider, sniffed at most once per process and
+    /// only when the config declares no providers at all.  Empty when nothing
+    /// could be sniffed.
+    zero_config_github: OnceCell<Vec<GitHub>>,
 }
 
 impl App {
     pub async fn new_static(config: Config) -> anyhow::Result<&'static App> {
-        Ok(Box::leak(Box::new(App { config })))
+        Ok(Box::leak(Box::new(App {
+            config,
+            zero_config_github: OnceCell::new(),
+        })))
+    }
+
+    /// The GitHub providers to fetch repositories from.
+    ///
+    /// Normally the configured ones, returned untouched.  Only when *no*
+    /// providers are configured at all does this fall back to a provider
+    /// sniffed from the environment (see [`crate::zero_config`]), so that a
+    /// fresh install works without a config file.  The sniff runs lazily — a
+    /// configured install never shells out to `gh`, and neither do commands
+    /// that don't list repositories — and at most once per process.
+    pub async fn github_providers(&self) -> &[GitHub] {
+        if !self.config.providers.is_empty() {
+            return &self.config.providers.github;
+        }
+
+        self.zero_config_github
+            .get_or_init(|| async {
+                let environment = zero_config::probe_environment().await;
+
+                match zero_config::default_github_provider(&environment) {
+                    Some(provider) => {
+                        tracing::debug!(
+                            current_user = provider.current_user.as_deref(),
+                            "no providers configured, using the default github.com provider"
+                        );
+
+                        vec![provider]
+                    }
+                    None => {
+                        eprintln!("{}", zero_config::NO_AUTH_HINT);
+
+                        Vec::new()
+                    }
+                }
+            })
+            .await
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[tokio::test]
+    async fn configured_providers_are_used_as_is() -> anyhow::Result<()> {
+        let config = Config::from_string(
+            r#"
+              [[providers.github]]
+              current_user = "kjuulh"
+              access_token = "some-token"
+              users = ["kjuulh"]
+              organisations = ["lunarway"]
+            "#,
+        )?;
+
+        let app = App::new_static(config).await?;
+
+        // Identical to the configured providers: no injected default, and no
+        // `gh` shell-out on this path.
+        assert_eq!(
+            app.github_providers().await,
+            app.config.providers.github.as_slice()
+        );
+        assert_eq!(app.github_providers().await.len(), 1);
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn a_configured_gitea_provider_also_suppresses_the_default() -> anyhow::Result<()> {
+        let config = Config::from_string(
+            r#"
+              [[providers.gitea]]
+              url = "https://git.front.kjuulh.io/api/v1"
+              current_user = "kjuulh"
+            "#,
+        )?;
+
+        let app = App::new_static(config).await?;
+
+        assert_eq!(app.github_providers().await, &[] as &[GitHub]);
+
+        Ok(())
     }
 }

--- a/crates/gitnow/src/commands/skill.rs
+++ b/crates/gitnow/src/commands/skill.rs
@@ -253,6 +253,24 @@ Config file location (in priority order):
 2. `GITNOW_CONFIG` environment variable
 3. `~/.config/gitnow/gitnow.toml`
 
+### Zero-config first run
+
+No configuration is required. When **no providers are configured at all**
+(missing config file, empty file, or only `[settings]`), gitnow synthesises an
+in-memory github.com provider for your own account:
+
+- Token: `gh auth token`, else `GH_TOKEN`, else `GITHUB_TOKEN`, else nothing.
+- Login: `gh api user --jq .login`, seeding `current_user` and `users`.
+- Host: github.com.
+
+Configuring *any* provider (GitHub or Gitea) disables this entirely — explicit
+config always wins, and `gh` is never invoked. Customising `[settings]` alone
+does not disable it; the trigger is about providers.
+
+The synthesised provider is never written to disk and the token is never
+persisted or logged. With no `gh` and no token variable, gitnow prints a hint
+to stderr and continues — it never prompts, so `--no-shell` automation is safe.
+
 ### Config file format (TOML)
 
 ```toml
@@ -316,6 +334,11 @@ Multiple provider entries are supported — gitnow aggregates repositories from 
 ## Typical workflows
 
 ### First-time setup
+With the GitHub CLI already authenticated (`gh auth login`), no setup is
+needed — run `gitnow` and your own GitHub repositories are indexed.
+
+To go beyond your own GitHub (other users, organisations, Gitea, GitHub
+Enterprise):
 1. Create `~/.config/gitnow/gitnow.toml` with at least one provider
 2. Run `gitnow update` to populate the cache
 3. Run `gitnow` to interactively search and clone a repo

--- a/crates/gitnow/src/config.rs
+++ b/crates/gitnow/src/config.rs
@@ -231,6 +231,19 @@ pub struct Providers {
     pub gitea: Vec<Gitea>,
 }
 
+impl Providers {
+    /// True when no provider at all is configured — the fresh-install case
+    /// where the config file is absent, empty, or declares only `[settings]`.
+    ///
+    /// This is the sole trigger for the zero-config default provider (see
+    /// [`crate::zero_config`]).  It looks at *providers* only: customising
+    /// settings does not turn the default off, and configuring any provider —
+    /// GitHub or Gitea — does.
+    pub fn is_empty(&self) -> bool {
+        self.github.is_empty() && self.gitea.is_empty()
+    }
+}
+
 #[derive(Debug, Serialize, Deserialize, PartialEq, Clone)]
 pub struct GitHub {
     #[serde(default)]
@@ -264,6 +277,12 @@ macro_rules! string_newtype {
                 value.0.as_str()
             }
         }
+
+        impl From<String> for $name {
+            fn from(value: String) -> Self {
+                Self(value)
+            }
+        }
     };
 }
 
@@ -286,19 +305,37 @@ pub struct Gitea {
     pub organisations: Vec<GiteaOrganisation>,
 }
 
-#[derive(Debug, Serialize, Deserialize, PartialEq, Clone)]
+#[derive(Serialize, Deserialize, PartialEq, Clone)]
 #[serde(untagged)]
 pub enum GiteaAccessToken {
     Direct(String),
     Env { env: String },
 }
 
-#[derive(Debug, Serialize, Deserialize, PartialEq, Clone)]
+#[derive(Serialize, Deserialize, PartialEq, Clone)]
 #[serde(untagged)]
 pub enum GitHubAccessToken {
     Direct(String),
     Env { env: String },
 }
+
+/// Redacts the literal token, so it cannot reach a log line, a panic message,
+/// or `--verbose` output by way of a `Debug` impl further up the tree.
+macro_rules! redacted_debug {
+    ($name:ident) => {
+        impl std::fmt::Debug for $name {
+            fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                match self {
+                    Self::Direct(_) => f.write_str("Direct(<redacted>)"),
+                    Self::Env { env } => f.debug_struct("Env").field("env", env).finish(),
+                }
+            }
+        }
+    };
+}
+
+redacted_debug!(GiteaAccessToken);
+redacted_debug!(GitHubAccessToken);
 
 string_newtype!(GiteaUser);
 string_newtype!(GiteaOrganisation);

--- a/crates/gitnow/src/main.rs
+++ b/crates/gitnow/src/main.rs
@@ -27,6 +27,7 @@ mod projects_list;
 mod shell;
 mod template_command;
 mod worktree;
+mod zero_config;
 
 #[derive(Parser)]
 #[command(

--- a/crates/gitnow/src/projects_list.rs
+++ b/crates/gitnow/src/projects_list.rs
@@ -89,7 +89,7 @@ mod implementation {
             let github_provider = self.app.github_provider();
 
             let mut repositories = Vec::new();
-            for github in self.app.config.providers.github.iter() {
+            for github in self.app.github_providers().await.iter() {
                 if let Some(_user) = &github.current_user {
                     let mut repos = github_provider
                         .list_repositories_for_current_user(

--- a/crates/gitnow/src/zero_config.rs
+++ b/crates/gitnow/src/zero_config.rs
@@ -1,0 +1,395 @@
+//! Zero-config first run.
+//!
+//! A fresh install has no config file at all.  [`crate::config::Config::from_file`]
+//! creates an empty one, which parses into a `Config` with no providers, and
+//! without providers there is nothing to search or clone — so a first run used
+//! to do nothing until the user hand-wrote a config.
+//!
+//! When — and only when — *no* providers are configured, gitnow sniffs the
+//! environment for GitHub credentials and synthesises a provider for
+//! github.com pointing at the user's own account.  The provider is layered on
+//! at runtime and never written to disk, which means:
+//!
+//! * the token is not persisted, and is re-resolved on every run, and
+//! * a config the user writes later simply takes over, with no migration.
+//!
+//! The trigger is [`crate::config::Providers::is_empty`] — *providers*, not
+//! settings.  Customising `[settings]` does not turn the default off, and
+//! configuring any provider (GitHub *or* Gitea) does.
+
+use std::process::Stdio;
+use std::time::Duration;
+
+use crate::config::{GitHub, GitHubAccessToken, GitHubUser};
+
+/// Environment variables consulted for a token, in precedence order, after
+/// `gh auth token` has come up empty.
+const TOKEN_ENV_VARS: [&str; 2] = ["GH_TOKEN", "GITHUB_TOKEN"];
+
+/// Upper bound on a single `gh` invocation, so a hanging or wedged `gh` cannot
+/// wedge gitnow along with it.
+const GH_TIMEOUT: Duration = Duration::from_secs(10);
+
+/// Stand-in for `current_user` when a token was found but the login could not
+/// be resolved (no `gh` on PATH).  gitnow only checks whether `current_user` is
+/// set; the value is never sent anywhere, as `/user/repos` is scoped by the
+/// token itself.
+const UNKNOWN_LOGIN: &str = "authenticated-user";
+
+/// Shown once, on stderr, when there is no config *and* nothing to sniff.
+/// A hint rather than an error: gitnow must never prompt or block automation
+/// (Claude Code and other callers pass `--no-shell`).
+pub const NO_AUTH_HINT: &str = "\
+gitnow: no providers configured and no GitHub auth found.
+  - run `gh auth login` — gitnow then uses your own GitHub automatically, or
+  - set GH_TOKEN or GITHUB_TOKEN in your environment, or
+  - write ~/.config/gitnow/gitnow.toml (see `gitnow skill`, or
+    https://github.com/understory-io/gitnow#configuration)";
+
+/// A snapshot of everything the sniff read from the environment.
+///
+/// Split out from the IO that gathers it so the precedence rules and the shape
+/// of the synthesised provider can be tested without a `gh` binary.
+#[derive(Default, PartialEq, Clone)]
+pub struct Environment {
+    /// Token reported by `gh auth token`, when `gh` is installed and authenticated.
+    pub gh_token: Option<String>,
+
+    /// Login reported by `gh api user`, when it could be resolved.
+    pub gh_login: Option<String>,
+
+    /// *Names* of the token environment variables that are set, in
+    /// [`TOKEN_ENV_VARS`] precedence order.  Only the names are kept: the value
+    /// is referenced indirectly via [`GitHubAccessToken::Env`] and resolved by
+    /// the provider at request time.
+    pub token_env_vars: Vec<String>,
+}
+
+/// Redacted — a token must never reach a log line or `--verbose` output.
+impl std::fmt::Debug for Environment {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("Environment")
+            .field("gh_token", &self.gh_token.as_ref().map(|_| Redacted))
+            .field("gh_login", &self.gh_login)
+            .field("token_env_vars", &self.token_env_vars)
+            .finish()
+    }
+}
+
+pub(crate) struct Redacted;
+
+impl std::fmt::Debug for Redacted {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str("<redacted>")
+    }
+}
+
+impl Environment {
+    /// The token to authenticate with: `gh auth token`, then `GH_TOKEN`, then
+    /// `GITHUB_TOKEN`, then nothing.
+    fn access_token(&self) -> Option<GitHubAccessToken> {
+        if let Some(token) = &self.gh_token {
+            return Some(GitHubAccessToken::Direct(token.clone()));
+        }
+
+        self.token_env_vars
+            .first()
+            .map(|env| GitHubAccessToken::Env { env: env.clone() })
+    }
+}
+
+/// Synthesise the default github.com provider for `env`, or `None` when no
+/// GitHub credentials could be found at all.
+///
+/// The shape matches what a user would hand-write for their own account:
+/// `url = None` (github.com), `current_user` set so `/user/repos` is fetched,
+/// and `users = [login]`.  Organisations are deliberately left empty —
+/// `/user/repos?type=all` already covers the org repositories the token can
+/// see, so seeding them would only cost extra requests.
+pub fn default_github_provider(env: &Environment) -> Option<GitHub> {
+    let access_token = env.access_token()?;
+    let login = env.gh_login.clone();
+
+    Some(GitHub {
+        url: None,
+        access_token,
+        current_user: Some(login.clone().unwrap_or_else(|| UNKNOWN_LOGIN.to_string())),
+        users: login
+            .map(|login| vec![GitHubUser::from(login)])
+            .unwrap_or_default(),
+        organisations: Vec::new(),
+    })
+}
+
+/// Read the environment: `gh auth token`, the token environment variables, and
+/// — only when there is a token worth using — the login from `gh api user`.
+pub async fn probe_environment() -> Environment {
+    let gh_token = gh(&["auth", "token"]).await;
+    let token_env_vars = present_token_env_vars(|key| std::env::var(key).ok());
+
+    // `gh api user` is a network round-trip; skip it when there is nothing to
+    // authenticate with anyway.
+    let gh_login = if gh_token.is_some() || !token_env_vars.is_empty() {
+        gh(&["api", "user", "--jq", ".login"]).await
+    } else {
+        None
+    };
+
+    Environment {
+        gh_token,
+        gh_login,
+        token_env_vars,
+    }
+}
+
+/// The token environment variables that are set to a non-empty value, in
+/// precedence order.  Takes the lookup as an argument so it can be tested
+/// without mutating the process environment.
+fn present_token_env_vars(lookup: impl Fn(&str) -> Option<String>) -> Vec<String> {
+    TOKEN_ENV_VARS
+        .iter()
+        .filter(|key| lookup(key).is_some_and(|value| !value.trim().is_empty()))
+        .map(|key| (*key).to_string())
+        .collect()
+}
+
+/// Run `gh` and return its trimmed stdout, or `None` for any reason it did not
+/// produce output: not installed, not authenticated, timed out, or failed.
+///
+/// stdin and stderr are closed so `gh` can never prompt and never writes to the
+/// user's terminal.  Neither stdout nor stderr is ever logged — stdout holds
+/// the token.
+async fn gh(args: &[&str]) -> Option<String> {
+    let command = tokio::process::Command::new("gh")
+        .args(args)
+        .stdin(Stdio::null())
+        .stderr(Stdio::null())
+        // So a `gh` that outlives the timeout below is reaped, not orphaned.
+        .kill_on_drop(true)
+        .output();
+
+    match tokio::time::timeout(GH_TIMEOUT, command).await {
+        Err(_) => {
+            tracing::debug!(args = ?args, "gh timed out, skipping");
+            None
+        }
+        Ok(Err(e)) => {
+            tracing::debug!(error = %e, args = ?args, "could not run gh, skipping");
+            None
+        }
+        Ok(Ok(output)) if !output.status.success() => {
+            tracing::debug!(
+                status = output.status.code(),
+                args = ?args,
+                "gh exited unsuccessfully, skipping"
+            );
+            None
+        }
+        Ok(Ok(output)) => {
+            let stdout = String::from_utf8_lossy(&output.stdout).trim().to_string();
+            (!stdout.is_empty()).then_some(stdout)
+        }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use crate::config::{Config, Gitea, Providers};
+
+    fn env(gh_token: Option<&str>, gh_login: Option<&str>, token_env_vars: &[&str]) -> Environment {
+        Environment {
+            gh_token: gh_token.map(str::to_string),
+            gh_login: gh_login.map(str::to_string),
+            token_env_vars: token_env_vars.iter().map(|v| (*v).to_string()).collect(),
+        }
+    }
+
+    #[test]
+    fn empty_providers_are_the_trigger() {
+        assert!(Providers::default().is_empty());
+        assert!(Config::from_string("").unwrap().providers.is_empty());
+    }
+
+    #[test]
+    fn any_configured_provider_disables_the_trigger() {
+        let github = Providers {
+            github: vec![default_github_provider(&env(Some("token"), None, &[])).unwrap()],
+            gitea: vec![],
+        };
+        assert!(!github.is_empty());
+
+        let gitea = Providers {
+            github: vec![],
+            gitea: vec![Gitea {
+                url: "https://gitea.example.com/api/v1".into(),
+                access_token: None,
+                current_user: None,
+                users: vec![],
+                organisations: vec![],
+            }],
+        };
+        assert!(!gitea.is_empty());
+    }
+
+    #[test]
+    fn customised_settings_alone_still_trigger() {
+        let config = Config::from_string(
+            r#"
+              [settings]
+              projects = { directory = "git" }
+              clone_command = "jj git clone {{ ssh_url }} {{ path }}"
+            "#,
+        )
+        .unwrap();
+
+        assert!(config.providers.is_empty());
+    }
+
+    #[test]
+    fn the_gh_cli_token_wins_over_the_environment() {
+        let provider = default_github_provider(&env(
+            Some("gh-cli-token"),
+            None,
+            &["GH_TOKEN", "GITHUB_TOKEN"],
+        ))
+        .unwrap();
+
+        assert_eq!(
+            provider.access_token,
+            GitHubAccessToken::Direct("gh-cli-token".into())
+        );
+    }
+
+    #[test]
+    fn gh_token_wins_over_github_token() {
+        let provider =
+            default_github_provider(&env(None, None, &["GH_TOKEN", "GITHUB_TOKEN"])).unwrap();
+
+        assert_eq!(
+            provider.access_token,
+            GitHubAccessToken::Env {
+                env: "GH_TOKEN".into()
+            }
+        );
+    }
+
+    #[test]
+    fn github_token_is_the_last_resort() {
+        let provider = default_github_provider(&env(None, None, &["GITHUB_TOKEN"])).unwrap();
+
+        assert_eq!(
+            provider.access_token,
+            GitHubAccessToken::Env {
+                env: "GITHUB_TOKEN".into()
+            }
+        );
+    }
+
+    #[test]
+    fn without_credentials_nothing_is_synthesised() {
+        assert_eq!(
+            default_github_provider(&env(None, Some("kjuulh"), &[])),
+            None
+        );
+        assert_eq!(default_github_provider(&Environment::default()), None);
+    }
+
+    #[test]
+    fn the_synthesised_provider_targets_your_own_github() {
+        let provider =
+            default_github_provider(&env(Some("gh-cli-token"), Some("kjuulh"), &[])).unwrap();
+
+        assert_eq!(provider.url, None, "github.com, not an enterprise host");
+        assert_eq!(provider.current_user, Some("kjuulh".into()));
+        assert_eq!(provider.users, vec![GitHubUser::from("kjuulh".to_string())]);
+        assert_eq!(provider.organisations, vec![]);
+    }
+
+    #[test]
+    fn without_a_login_your_own_repos_are_still_listed() {
+        let provider = default_github_provider(&env(Some("gh-cli-token"), None, &[])).unwrap();
+
+        // `current_user` drives `/user/repos`, which the token alone scopes.
+        assert!(provider.current_user.is_some());
+        assert_eq!(provider.users, vec![]);
+    }
+
+    #[test]
+    fn only_non_empty_token_variables_count() {
+        let present = present_token_env_vars(|key| match key {
+            "GH_TOKEN" => Some("   ".to_string()),
+            "GITHUB_TOKEN" => Some("token".to_string()),
+            _ => None,
+        });
+
+        assert_eq!(present, vec!["GITHUB_TOKEN".to_string()]);
+        assert_eq!(present_token_env_vars(|_| None), Vec::<String>::new());
+    }
+
+    #[test]
+    fn environment_tokens_are_referenced_by_name_never_by_value() {
+        let provider = default_github_provider(&env(None, None, &["GH_TOKEN"])).unwrap();
+
+        // The value is resolved by the provider at request time, so it never
+        // even enters the synthesised config.
+        assert_eq!(
+            provider.access_token,
+            GitHubAccessToken::Env {
+                env: "GH_TOKEN".into()
+            }
+        );
+    }
+
+    #[test]
+    fn debug_output_redacts_tokens() {
+        let environment = env(Some("super-secret"), Some("kjuulh"), &["GH_TOKEN"]);
+        let provider = default_github_provider(&environment).unwrap();
+
+        for rendered in [format!("{environment:?}"), format!("{provider:?}")] {
+            assert!(
+                !rendered.contains("super-secret"),
+                "token leaked into debug output: {rendered}"
+            );
+            assert!(
+                rendered.contains("<redacted>"),
+                "expected a redaction marker in: {rendered}"
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn a_sniffed_token_is_never_written_to_the_config_file() -> anyhow::Result<()> {
+        let path = std::env::temp_dir()
+            .join(format!("gitnow-zero-config-{}", uuid::Uuid::new_v4()))
+            .join("gitnow.toml");
+
+        // A fresh install: the file does not exist yet.
+        let config = Config::from_file(&path).await?;
+        assert!(config.providers.is_empty());
+
+        let provider = default_github_provider(&env(Some("super-secret"), Some("kjuulh"), &[]))
+            .expect("a provider should be synthesised");
+
+        // Synthesising and injecting the provider must not touch the file.
+        let mut config = config;
+        config.providers.github.push(provider);
+
+        let on_disk = tokio::fs::read_to_string(&path).await?;
+        assert_eq!(on_disk, "", "the config file must stay untouched");
+        assert!(!on_disk.contains("super-secret"));
+
+        tokio::fs::remove_dir_all(path.parent().unwrap()).await?;
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn probing_a_bare_environment_finds_nothing_and_does_not_panic() {
+        // `gh` may or may not exist on the machine running the tests; either
+        // way the probe must return, not hang or panic.
+        let environment = probe_environment().await;
+
+        let _ = default_github_provider(&environment);
+    }
+}


### PR DESCRIPTION
## Headline

**A fresh `gitnow` install now works with zero configuration** — it sniffs `gh` for your own GitHub. Explicit config still wins, and the token is never persisted.

Previously `Config::from_file` created an *empty* config file on first run, which parsed into a `Config` with no providers — so there was nothing to search or clone until you hand-wrote a config.

## The trigger predicate

`Providers::is_empty()` — **both** provider lists empty (`providers.github.is_empty() && providers.gitea.is_empty()`). That covers the three fresh-install shapes: no config file, an empty file, and a file with only `[settings]`.

- Configuring **any** provider — GitHub *or* Gitea — turns the sniff off entirely. Configured providers are used exactly as written, never merged into or reordered, and `gh` is never invoked.
- Customising `[settings]` alone does **not** turn it off. The trigger is deliberately about *providers*, not settings.

## Env precedence

| | Source | Fallback |
| --- | --- | --- |
| Token | `gh auth token` | `GH_TOKEN`, then `GITHUB_TOKEN`, then none |
| Login | `gh api user --jq .login` | none needed — the token alone scopes `/user/repos` |
| Host | `github.com` (`url = None`) | — |

Synthesised shape: `url: None`, `current_user: Some(login)`, `users: [login]`, `organisations: []`. Orgs are deliberately not seeded — `/user/repos?type=all` already covers the org repositories the token can see, so seeding them only costs extra requests. Verified: indexing with and without the `gh` login yields the identical 649 repositories.

## Why the token isn't persisted

The provider is layered on **at runtime only** — nothing is ever written to the config file, so the `gh` token never lands on disk and is re-resolved each run. Concretely:

- `gh auth token` → `GitHubAccessToken::Direct`, in memory for the life of the process.
- `GH_TOKEN` / `GITHUB_TOKEN` → `GitHubAccessToken::Env { env }` indirection. Only the **variable name** is kept; the value is resolved by the provider at request time and never enters the synthesised config.
- `GitHubAccessToken` and `GiteaAccessToken` now implement `Debug` manually, rendering `Direct(<redacted>)`, so a token can't reach a log line or `--verbose` output via a `Debug` impl further up the tree. `gh`'s stdout and stderr are never logged either.

A config written later simply takes over, with no migration.

## Behaviour when nothing is available

No `gh` and no token variable ⇒ a one-line hint on stderr, then normal operation:

```
gitnow: no providers configured and no GitHub auth found.
  - run `gh auth login` — gitnow then uses your own GitHub automatically, or
  - set GH_TOKEN or GITHUB_TOKEN in your environment, or
  - write ~/.config/gitnow/gitnow.toml (see `gitnow skill`, or
    https://github.com/understory-io/gitnow#configuration)
```

No panic, no prompt, no interactive blocking — `--no-shell` automation (Claude Code, the skills tooling) is unaffected.

## Fast and best-effort

The sniff is **lazy and memoised** on `App`: it runs at most once per process, and only for commands that actually list repositories. A configured install never shells out to `gh`, and neither do `gitnow init zsh` or `gitnow skill` even on an empty config — verified with a fake `gh` on `PATH` that records invocations (0 for both). Each `gh` call is `stdin`/`stderr`-closed, `kill_on_drop`, and capped at a 10s timeout so a wedged `gh` can't wedge gitnow. No new dependencies: it shells out to `gh` the way the repo already shells out to `git`.

## Verification

End-to-end, against a pristine `HOME` (real GitHub, real `gh`):

| Scenario | Result |
| --- | --- |
| Fresh install, `gh` authed, no config | ✅ `gitnow update` indexed 649 repos; `gitnow gitnow` resolved `github.com/understory-io/gitnow`; config file left empty |
| `gh` absent, `GITHUB_TOKEN` set | ✅ same 649 repos via the `Env` indirection |
| `gh` present but failing, `GITHUB_TOKEN` set | ✅ consulted `gh` first, fell through to the env var |
| Config present (gitea-only) | ✅ `gh` invoked 0 times, no injected default |
| Empty config, `init zsh` / `skill` | ✅ `gh` invoked 0 times |
| No `gh`, no token env | ✅ friendly hint, exit 0, no panic |
| Secret hygiene | ✅ token found in 0 files under the fresh `HOME` |

Unit tests (12 new, 34 total green) cover the trigger predicate (empty vs. GitHub-configured vs. Gitea-configured vs. settings-only), the full env precedence chain, the synthesised provider shape, the no-login path, `Debug` redaction, and that a sniffed token is not written to the config file.

`cargo build` and `cargo test` are green.

⚠️ `cargo fmt --check` and `cargo clippy -D warnings` are **already red on `main`** — 14 of 26 source files are fmt-dirty and there are 6 clippy lints (3 × `collapsible_if`, `let_and_return`, `too_many_arguments`, `str::replace`), all from the newer toolchain's edition-2024 import ordering and lint set. This branch adds **zero** new fmt or clippy findings (the counts are byte-identical to `main`), and I deliberately left the pre-existing churn out to keep the diff focused. Happy to send a separate `cargo fmt` + clippy-cleanup PR if you want it.

## Docs

README gets a "Zero-config first run" section; `gitnow skill` gets the same for the LLM reference (plus an updated first-time-setup flow); CHANGELOG under `[Unreleased]`.

No gitnow/DATA ticket covers this — searched Linear and found none, so noting it here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
