### PR TITLE
chore(release): v0.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.7.0] - 2026-09-10
+
 ### Added
 - `gitnow list` prints the known repository set non-interactively, with `--json`, `--cloned` and query filtering
 - work with zero configuration on a fresh install: when no providers are configured, gitnow sniffs `gh auth token` (falling back to `GH_TOKEN`/`GITHUB_TOKEN`) and the `gh` login to index your own GitHub. Configuring any provider disables the sniff, and the token is never persisted to the config file nor printed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -684,7 +684,7 @@ dependencies = [
 
 [[package]]
 name = "gitnow"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/*"]
 resolver = "2"
 
 [workspace.package]
-version = "0.6.0"
+version = "0.7.0"
 
 [workspace.dependencies]
 


### PR DESCRIPTION
Cuts **v0.7.0** — a minor bump, since 0.6.0 gained two features and one fix:

### Added
- `gitnow list` (#27)
- zero-config first run (#29)

### Fixed
- `~` expansion in `settings.projects.directory` / `settings.cache.location` (#28)

Bumps the workspace version and `Cargo.lock`, and moves the `[Unreleased]` entries into a dated `[0.7.0]` section. `cargo test` green at 37/37.

Tagging `v0.7.0` after this merges drives the Woodpecker release job (GoReleaser → git.kjuulh.io + homebrew tap); the forest `external:` component in `forest.cue` gets its version and hashes updated once the tarballs exist.

🤖 Generated with [Claude Code](https://claude.com/claude-code)